### PR TITLE
replace tasks.mjs with npm scripts. add tsx, rimraf and glob to do so.

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,0 +1,23 @@
+name: compile typescript
+
+on: [pull_request]
+
+jobs:
+  compile:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install Dependencies
+        run: yarn --immutable
+      - name: Compile
+        run: yarn compile

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,9 @@
-name: build and test codebase
+name: test codebase
 
 on: [pull_request]
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -19,7 +19,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
         run: yarn --immutable
-      - name: Build
-        run: yarn build
       - name: Test
         run: npm test

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ attribute.
 
 - `yarn bundle` -> Bundles the whole code into a single javascript file which
   will be stored inside the dist folder. For prod deployments you typically just
-copy this file somewhere and then run something like `node --enable-source-maps
+  copy this file somewhere and then run something like `node --enable-source-maps
 ./index.js`.
 - `yarn clean` -> Removes bundled files by deleting the dist folder. Normally
   there is no need to invoke this manually.
@@ -90,7 +90,7 @@ copy this file somewhere and then run something like `node --enable-source-maps
   codebase. Displays any errors if they occur.
 - `yarn compile-watch` -> Runs the typescript compiler every time you make
   changes to a file. It is good to open this in another terminal while
-developing to spot typescript issues.
+  developing to spot typescript issues.
 - `yarn dev` -> This should be used for running the code while developing. It
   watches all changes you make to your typescript codebase and automatically
   rebuilds the project. It does also watch all changes made to the built project
@@ -106,7 +106,7 @@ developing to spot typescript issues.
 - `yarn start` -> Runs the code. This only works if the code was bundled before ;).
 - `yarn test` -> Tests your codebase. Basic tests are created for both major
   approaches of putting tests beside the source code as well as putting tests in
-a seperate folder.
+  a seperate folder.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ running with a new project in no time. It provides:
   compatible with the operating systems linux, macos and windows.
 - Github Actions in place runnung with current node version (18,20) on linux,
   macos and windows to automatically (for each PR):
-  - build and test the code
+  - test the code
+  - compile the codebase from ts to js
   - check for formatting issues
-  - lint the codebase
+  - check for linting issues
 - Testing via the new Node.js [test
   runner](https://nodejs.org/api/test.html#test-runner) instead of something
   like mocha or jest.
@@ -77,19 +78,19 @@ add . && git commit -am "initial commit"`
 ## Scripts and their explanation
 
 All scripts can be found inside the package.json file under the "scripts"
-attribute. They simply invoke the `tasks.mjs` file which handles the logic
-behind these scripts. The `tasks.mjs` file was created in order to be able to
-easily implement operating system dependant code and leverage comments. You can
-just take a look inside the tasks.mjs file in order to understand what is going
-on behind the scenes. It contains comments for every script.
+attribute.
 
-- `yarn build` -> Builds the project. It transpiles the typescript code to
-  javascript and stores the output inside the dist folder. Deletes any files
-  from previous builds beforehand to become repeatable/idempotent.
 - `yarn bundle` -> Bundles the whole code into a single javascript file which
-  will be stored inside the bundle folder.
-- `yarn clean` -> Removes built files. Deletes the dist and bundle directory and
-  the files inside of them. Normally there is no need to invoke this manually.
+  will be stored inside the dist folder. For prod deployments you typically just
+copy this file somewhere and then run something like `node --enable-source-maps
+./index.js`.
+- `yarn clean` -> Removes bundled files by deleting the dist folder. Normally
+  there is no need to invoke this manually.
+- `yarn compile` -> Runs the typescript compiler against the typescript
+  codebase. Displays any errors if they occur.
+- `yarn compile-watch` -> Runs the typescript compiler every time you make
+  changes to a file. It is good to open this in another terminal while
+developing to spot typescript issues.
 - `yarn dev` -> This should be used for running the code while developing. It
   watches all changes you make to your typescript codebase and automatically
   rebuilds the project. It does also watch all changes made to the built project
@@ -102,10 +103,10 @@ on behind the scenes. It contains comments for every script.
   auto-fixable and reports the rest of them to you.
 - `yarn lint-check` -> Checks for linting errors using eslint. This is typically
   only invoked by the CI/CD pipeline.
-- `yarn start` -> Runs the code. This only works if the code was built before ;).
+- `yarn start` -> Runs the code. This only works if the code was bundled before ;).
 - `yarn test` -> Tests your codebase. Basic tests are created for both major
   approaches of putting tests beside the source code as well as putting tests in
-  a seperate folder.
+a seperate folder.
 
 ## Debugging
 

--- a/package.json
+++ b/package.json
@@ -28,18 +28,17 @@
   "author": "Pierre Dahmani <hi@pierre-dev.com>",
   "license": "MIT",
   "scripts": {
-    "build": "node tasks.mjs build",
-    "bundle": "node tasks.mjs bundle",
-    "clean": "node tasks.mjs clean",
-    "dev": "concurrently \"npm:watch-*\"",
-    "format": "node tasks.mjs format --write",
-    "format-check": "node tasks.mjs format --check",
-    "lint": "node tasks.mjs lint --fix",
-    "lint-check": "node tasks.mjs lint",
-    "start": "node tasks.mjs start",
-    "test": "node tasks.mjs test",
-    "watch-node": "node tasks.mjs watch-node",
-    "watch-ts": "node tasks.mjs watch-ts"
+    "bundle": "esbuild src/index.ts --outdir=dist --sourcemap --bundle --platform=node --target=node20.10.0",
+    "clean": "rimraf dist",
+    "compile": "tsc",
+    "compile-watch": "tsc -w",
+    "dev": "nodemon --watch src --watch test --ext ts,json --exec 'yarn bundle && yarn start'",
+    "format": "prettier . --write",
+    "format-check": "prettier . --check",
+    "lint": "eslint . --fix",
+    "lint-check": "eslint .",
+    "start": "node --enable-source-maps ./dist/index.js",
+    "test": "glob src/**/*.test.ts test/** -c 'tsx --test'"
   },
   "devDependencies": {
     "@tsconfig/node20": "20.1.2",
@@ -52,9 +51,12 @@
     "esbuild": "0.19.10",
     "eslint": "8.56.0",
     "eslint-config-prettier": "8.10.0",
+    "glob": "10.3.10",
     "nodemon": "2.0.22",
     "prettier": "3.2.4",
+    "rimraf": "5.0.5",
     "shelljs": "0.8.5",
+    "tsx": "4.7.0",
     "typescript": "5.3.3"
   },
   "packageManager": "yarn@4.0.2"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --fix",
     "lint-check": "eslint .",
     "start": "node --enable-source-maps ./dist/index.js",
-    "test": "glob src/**/*.test.ts test/** -c 'tsx --test'"
+    "test": "glob 'src/**/*.test.ts' 'test/**' -c 'tsx --test'"
   },
   "devDependencies": {
     "@tsconfig/node20": "20.1.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint . --fix",
     "lint-check": "eslint .",
     "start": "node --enable-source-maps ./dist/index.js",
-    "test": "glob 'src/**/*.test.ts' 'test/**' -c 'tsx --test'"
+    "test": "glob \"src/**/*.test.ts\" \"test/**\" -c \"tsx --test\""
   },
   "devDependencies": {
     "@tsconfig/node20": "20.1.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,9 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true,
   },
   "include": ["src", "test"],
-  "exclude": ["dist", "bundle", "node_modules"]
+  "exclude": ["dist", "bundle", "node_modules"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/aix-ppc64@npm:0.19.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/android-arm64@npm:0.19.10"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-arm64@npm:0.19.12"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -42,9 +56,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-arm@npm:0.19.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/android-x64@npm:0.19.10"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-x64@npm:0.19.12"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -56,9 +84,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/darwin-arm64@npm:0.19.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/darwin-x64@npm:0.19.10"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/darwin-x64@npm:0.19.12"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -70,9 +112,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.19.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/freebsd-x64@npm:0.19.10"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/freebsd-x64@npm:0.19.12"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -84,9 +140,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-arm64@npm:0.19.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/linux-arm@npm:0.19.10"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-arm@npm:0.19.12"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -98,9 +168,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-ia32@npm:0.19.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/linux-loong64@npm:0.19.10"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-loong64@npm:0.19.12"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -112,9 +196,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-mips64el@npm:0.19.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/linux-ppc64@npm:0.19.10"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-ppc64@npm:0.19.12"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -126,9 +224,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-riscv64@npm:0.19.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/linux-s390x@npm:0.19.10"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-s390x@npm:0.19.12"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -140,9 +252,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-x64@npm:0.19.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/netbsd-x64@npm:0.19.10"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/netbsd-x64@npm:0.19.12"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -154,9 +280,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/openbsd-x64@npm:0.19.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/sunos-x64@npm:0.19.10"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/sunos-x64@npm:0.19.12"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -168,6 +308,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-arm64@npm:0.19.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/win32-ia32@npm:0.19.10"
@@ -175,9 +322,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-ia32@npm:0.19.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.19.10":
   version: 0.19.10
   resolution: "@esbuild/win32-x64@npm:0.19.10"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-x64@npm:0.19.12"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -995,6 +1156,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:~0.19.10":
+  version: 0.19.12
+  resolution: "esbuild@npm:0.19.12"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.19.12"
+    "@esbuild/android-arm": "npm:0.19.12"
+    "@esbuild/android-arm64": "npm:0.19.12"
+    "@esbuild/android-x64": "npm:0.19.12"
+    "@esbuild/darwin-arm64": "npm:0.19.12"
+    "@esbuild/darwin-x64": "npm:0.19.12"
+    "@esbuild/freebsd-arm64": "npm:0.19.12"
+    "@esbuild/freebsd-x64": "npm:0.19.12"
+    "@esbuild/linux-arm": "npm:0.19.12"
+    "@esbuild/linux-arm64": "npm:0.19.12"
+    "@esbuild/linux-ia32": "npm:0.19.12"
+    "@esbuild/linux-loong64": "npm:0.19.12"
+    "@esbuild/linux-mips64el": "npm:0.19.12"
+    "@esbuild/linux-ppc64": "npm:0.19.12"
+    "@esbuild/linux-riscv64": "npm:0.19.12"
+    "@esbuild/linux-s390x": "npm:0.19.12"
+    "@esbuild/linux-x64": "npm:0.19.12"
+    "@esbuild/netbsd-x64": "npm:0.19.12"
+    "@esbuild/openbsd-x64": "npm:0.19.12"
+    "@esbuild/sunos-x64": "npm:0.19.12"
+    "@esbuild/win32-arm64": "npm:0.19.12"
+    "@esbuild/win32-ia32": "npm:0.19.12"
+    "@esbuild/win32-x64": "npm:0.19.12"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 861fa8eb2428e8d6521a4b7c7930139e3f45e8d51a86985cc29408172a41f6b18df7b3401e7e5e2d528cdf83742da601ddfdc77043ddc4f1c715a8ddb2d8a255
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -1276,7 +1517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -1286,7 +1527,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -1309,6 +1550,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-tsconfig@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "get-tsconfig@npm:4.7.2"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: f21135848fb5d16012269b7b34b186af7a41824830f8616aba17a15eb4d9e54fdc876833f1e21768395215a826c8145582f5acd594ae2b4de3284d10b38d20f8
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
@@ -1327,7 +1577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10":
+"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
   dependencies:
@@ -1916,9 +2166,12 @@ __metadata:
     esbuild: "npm:0.19.10"
     eslint: "npm:8.56.0"
     eslint-config-prettier: "npm:8.10.0"
+    glob: "npm:^10.3.10"
     nodemon: "npm:2.0.22"
     prettier: "npm:3.2.4"
+    rimraf: "npm:5.0.5"
     shelljs: "npm:0.8.5"
+    tsx: "npm:^4.7.0"
     typescript: "npm:5.3.3"
   bin:
     nodejs-typescript-modern-starter: dist/src/index.js
@@ -2179,6 +2432,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 0763150adf303040c304009231314d1e84c6e5ebfa2d82b7d94e96a6e82bacd1dcc0b58ae257315f3c8adb89a91d8d0f12928241cba2df1680fbe6f60bf99b0e
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.1.6":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
@@ -2216,6 +2476,17 @@ __metadata:
   version: 1.0.4
   resolution: "reusify@npm:1.0.4"
   checksum: 14222c9e1d3f9ae01480c50d96057228a8524706db79cdeb5a2ce5bb7070dd9f409a6f84a02cbef8cdc80d39aef86f2dd03d155188a1300c599b05437dcd2ffb
+  languageName: node
+  linkType: hard
+
+"rimraf@npm:5.0.5":
+  version: 5.0.5
+  resolution: "rimraf@npm:5.0.5"
+  dependencies:
+    glob: "npm:^10.3.7"
+  bin:
+    rimraf: dist/esm/bin.mjs
+  checksum: a612c7184f96258b7d1328c486b12ca7b60aa30e04229a08bbfa7e964486deb1e9a1b52d917809311bdc39a808a4055c0f950c0280fba194ba0a09e6f0d404f6
   languageName: node
   linkType: hard
 
@@ -2540,6 +2811,22 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: ea036bec1dd024e309939ffd49fda7a351c0e87a1b8eb049570dd119d447250e2c56e0e6c00554e8205760e7417793fdebff752a46e573fbe07d4f375502a5b2
+  languageName: node
+  linkType: hard
+
+"tsx@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "tsx@npm:4.7.0"
+  dependencies:
+    esbuild: "npm:~0.19.10"
+    fsevents: "npm:~2.3.3"
+    get-tsconfig: "npm:^4.7.2"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    tsx: dist/cli.mjs
+  checksum: 3e6ee0a0a8adb7b1cb58875f50b143b41df0132ade3a7cdda16a166ac473eee446197762ba6afb235ace4c6adae7e55f61a420ee55b17438717eea1e55e611c0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,7 +1577,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
+"glob@npm:10.3.10, glob@npm:^10.2.2, glob@npm:^10.3.10, glob@npm:^10.3.7":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
   dependencies:
@@ -2166,12 +2166,12 @@ __metadata:
     esbuild: "npm:0.19.10"
     eslint: "npm:8.56.0"
     eslint-config-prettier: "npm:8.10.0"
-    glob: "npm:^10.3.10"
+    glob: "npm:10.3.10"
     nodemon: "npm:2.0.22"
     prettier: "npm:3.2.4"
     rimraf: "npm:5.0.5"
     shelljs: "npm:0.8.5"
-    tsx: "npm:^4.7.0"
+    tsx: "npm:4.7.0"
     typescript: "npm:5.3.3"
   bin:
     nodejs-typescript-modern-starter: dist/src/index.js
@@ -2814,7 +2814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsx@npm:^4.7.0":
+"tsx@npm:4.7.0":
   version: 4.7.0
   resolution: "tsx@npm:4.7.0"
   dependencies:


### PR DESCRIPTION
get rid of tasks.mjs file. Try to reduce overhead by just using the package.json scripts. Added tsx, rimraf and glob to be able to do so.